### PR TITLE
Refactor: Admin 공통 응답객체 적용 및 QueryDSL 페이지네이션으로 리펙토링

### DIFF
--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -63,7 +63,7 @@ public class AdminController {
     }
 
     @GetMapping("/statistic")
-    public ResponseEntity<Map<String, List<?>>> statistic() {
+    public ApiResponse<Map<String, List<?>>> statistic() {
         List<CountriesStatisticResponse> countriesStatisticResponses = adminService.getCountriesStatistics();
         List<MonthlyStatisticResponse> monthlyStatisticResponses = adminService.getMonthStatistics();
         Map<String, List<?>> statistics = new HashMap<>() {
@@ -75,19 +75,19 @@ public class AdminController {
 
         log.info(statistics.toString());
 
-        return ResponseEntity.ok(statistics);
+        return ApiResponse.success(statistics);
     }
 
     @GetMapping("/valid-email")
-    public ResponseEntity<Map<String, Boolean>> validateEmail(@RequestParam("email") String email) {
+    public ApiResponse<Map<String, Boolean>> validateEmail(@RequestParam("email") String email) {
         boolean isDuplicatedEmail = adminService.isDuplicatedEmail(email);
-        return ResponseEntity.ok(isDuplicatedEmail ? Collections.singletonMap("duplicated", true) : Collections.emptyMap());
+        return ApiResponse.success(isDuplicatedEmail ? Collections.singletonMap("duplicated", true) : Collections.emptyMap());
     }
 
     @GetMapping("/valid-name")
-    public ResponseEntity<Map<String, Boolean>> validateName(@RequestParam("name") String name) {
+    public ApiResponse<Map<String, Boolean>> validateName(@RequestParam("name") String name) {
         boolean isDuplicatedName = adminService.isDuplicatedUsername(name);
-        return ResponseEntity.ok(isDuplicatedName ? Collections.singletonMap("duplicated", true) : Collections.emptyMap());
+        return ApiResponse.success(isDuplicatedName ? Collections.singletonMap("duplicated", true) : Collections.emptyMap());
     }
 
     private Map<String, String> createSuccessMessage(String message) {

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -11,11 +11,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -23,10 +22,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin")
@@ -42,7 +40,7 @@ public class AdminController {
     @GetMapping("/user-info")
     public ResponseEntity<Page<UserInfoResponse>> userInfos(
         @RequestParam(name = "page", defaultValue = "0") int page,
-        @RequestParam(name = "size", defaultValue = "15") int size
+        @RequestParam(name = "size", defaultValue = "16") int size
     ) {
         int minPageLimit = Math.max(0, page);
         return ResponseEntity.ok(adminService.findAll(PageRequest.of(minPageLimit, size)));
@@ -98,9 +96,14 @@ public class AdminController {
     public ResponseEntity<Map<String, List<?>>> statistic() {
         List<CountriesStatisticResponse> countriesStatisticResponses = adminService.getCountriesStatistics();
         List<MonthlyStatisticResponse> monthlyStatisticResponses = adminService.getMonthStatistics();
-        Map<String, List<?>> statistics = new HashMap<>();
-        statistics.put("countries", countriesStatisticResponses);
-        statistics.put("monthly", monthlyStatisticResponses);
+        Map<String, List<?>> statistics = new HashMap<>() {
+            {
+                put("countries", countriesStatisticResponses);
+                put("monthly", monthlyStatisticResponses);
+            }
+        };
+
+        log.info(statistics.toString());
 
         return ResponseEntity.ok(statistics);
     }

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -6,6 +6,7 @@ import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserInfoResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserInfoUpdateRequest;
 import grepp.NBE5_6_2_Team03.domain.admin.AdminService;
 import grepp.NBE5_6_2_Team03.global.exception.NotFoundException;
+import grepp.NBE5_6_2_Team03.global.response.ApiResponse;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -38,31 +39,31 @@ public class AdminController {
     }
 
     @GetMapping("/user-info")
-    public ResponseEntity<Page<UserInfoResponse>> userInfos(
+    public ApiResponse<Page<UserInfoResponse>> userInfos(
         @RequestParam(name = "page", defaultValue = "0") int page,
         @RequestParam(name = "size", defaultValue = "16") int size
     ) {
         int minPageLimit = Math.max(0, page);
-        return ResponseEntity.ok(adminService.findAll(PageRequest.of(minPageLimit, size)));
+        return ApiResponse.success(adminService.findAll(PageRequest.of(minPageLimit, size)));
     }
 
     @PatchMapping("/user-info/{id}/edit")
-    public ResponseEntity<Map<String, String>> editUserInfo(
+    public ApiResponse<Map<String, String>> editUserInfo(
         @PathVariable("id") Long id,
         @RequestBody UserInfoUpdateRequest request
     ) {
         String message = null;
 
         adminService.updateUserInfo(id, request);
-        return ResponseEntity.ok(createSuccessMessage("유저 정보가 성공적으로 수정되었습니다."));
+        return ApiResponse.success(createSuccessMessage("유저 정보가 성공적으로 수정되었습니다."));
     }
 
     @DeleteMapping("/user-info/{id}/delete")
-    public ResponseEntity<Map<String, String>> deleteUserInfo(
+    public ApiResponse<Map<String, String>> deleteUserInfo(
         @PathVariable("id") Long id
     ) {
         adminService.deleteById(id);
-        return ResponseEntity.ok(createSuccessMessage("유저를 탈퇴처리 하였습니다."));
+        return ApiResponse.success(createSuccessMessage("유저를 탈퇴처리 하였습니다."));
     }
 
     private static Map<String, String> getMessage(String message) {

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -50,8 +50,6 @@ public class AdminController {
         @PathVariable("id") Long id,
         @RequestBody UserInfoUpdateRequest request
     ) {
-        String message = null;
-
         adminService.updateUserInfo(id, request);
         return ApiResponse.success(createSuccessMessage("유저 정보가 성공적으로 수정되었습니다."));
     }
@@ -62,13 +60,6 @@ public class AdminController {
     ) {
         adminService.deleteById(id);
         return ApiResponse.success(createSuccessMessage("유저를 탈퇴처리 하였습니다."));
-    }
-
-    private static Map<String, String> getMessage(String message) {
-        return Map.of(
-            "message", message,
-            "redirect", "/admin/user-info"
-        );
     }
 
     @GetMapping("/statistic")

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -4,8 +4,8 @@ import grepp.NBE5_6_2_Team03.api.controller.admin.dto.statistic.CountriesStatist
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.statistic.MonthlyStatisticResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserInfoResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserInfoUpdateRequest;
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserSearchRequest;
 import grepp.NBE5_6_2_Team03.domain.admin.AdminService;
-import grepp.NBE5_6_2_Team03.global.exception.NotFoundException;
 import grepp.NBE5_6_2_Team03.global.response.ApiResponse;
 import java.util.Collections;
 import java.util.HashMap;
@@ -14,10 +14,10 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,14 +38,11 @@ public class AdminController {
         return "admin/dashboard";
     }
 
-    // FIXME QueryDSL 페이지네이션 적용
     @GetMapping("/user-info")
     public ApiResponse<Page<UserInfoResponse>> userInfos(
-        @RequestParam(name = "page", defaultValue = "0") int page,
-        @RequestParam(name = "size", defaultValue = "16") int size
+        @ModelAttribute UserSearchRequest request
     ) {
-        int minPageLimit = Math.max(0, page);
-        return ApiResponse.success(adminService.findAll(PageRequest.of(minPageLimit, size)));
+        return ApiResponse.success(adminService.findUsersPage(request));
     }
 
     @PatchMapping("/user-info/{id}/edit")

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -45,82 +45,75 @@ public class AdminController {
         @RequestParam(name = "size", defaultValue = "15") int size
     ) {
         int minPageLimit = Math.max(0, page);
-        Page<UserInfoResponse> userPage = adminService.findAll(PageRequest.of(minPageLimit, size));
-//        model.addAttribute("userPage", userPage);
-//        return "admin/user-info";
-        return ResponseEntity.ok(userPage);
+        return ResponseEntity.ok(adminService.findAll(PageRequest.of(minPageLimit, size)));
     }
 
     @PatchMapping("/user-info/{id}/edit")
-    public ResponseEntity<String> editUserInfo(
+    public ResponseEntity<Map<String, String>> editUserInfo(
         @PathVariable("id") Long id,
-        @RequestBody UserInfoUpdateRequest request,
-        RedirectAttributes redirectAttributes) {
+        @RequestBody UserInfoUpdateRequest request
+    ) {
 
         String message = null;
 
         try {
             adminService.updateUserInfo(id, request);
             message =  "유저 정보가 성공적으로 수정되었습니다.";
-            return ResponseEntity.ok(message);
+            return ResponseEntity.ok(getMessage(message));
         } catch (NotFoundException e) {
             message =  e.getMessage();
-            return ResponseEntity.status(403).body(message);
+            return ResponseEntity.status(403).body(getMessage(message));
         } catch (Exception e) {
             message = "알 수 없는 이유로 취소되었습니다.";
         }
-
-//        return "redirect:/admin/user-info";
-        return ResponseEntity.status(500).body(message);
+        return ResponseEntity.status(500).body(getMessage(message));
     }
 
     @DeleteMapping("/user-info/{id}/delete")
-    public ResponseEntity<String> deleteUserInfo(
-        @PathVariable("id") Long id,
-        RedirectAttributes redirectAttributes
+    public ResponseEntity<Map<String, String>> deleteUserInfo(
+        @PathVariable("id") Long id
     ) {
         String message = null;
         try {
             adminService.deleteById(id);
             message =  "유저를 탈퇴처리 하였습니다.";
-            return ResponseEntity.ok(message);
+            return ResponseEntity.ok(getMessage(message));
         } catch ( NotFoundException e ) {
             message =  e.getMessage();
-            return ResponseEntity.status(403).body(message);
+            return ResponseEntity.status(403).body(getMessage(message));
         } catch (Exception e) {
             message = "알 수 없는 이유로 취소되었습니다.";
         }
-//        return "redirect:/admin/user-info";
-        return ResponseEntity.status(500).body(message);
+        return ResponseEntity.status(500).body(getMessage(message));
+    }
+
+    private static Map<String, String> getMessage(String message) {
+        return Map.of(
+            "message", message,
+            "redirect", "/admin/user-info"
+        );
     }
 
     @GetMapping("/statistic")
     public ResponseEntity<Map<String, List<?>>> statistic() {
         List<CountriesStatisticResponse> countriesStatisticResponses = adminService.getCountriesStatistics();
         List<MonthlyStatisticResponse> monthlyStatisticResponses = adminService.getMonthStatistics();
-//        model.addAttribute("countriesStatisticResponses", countriesStatisticResponses);
-//        model.addAttribute("monthlyStatisticResponses", monthlyStatisticResponses);
         Map<String, List<?>> statistics = new HashMap<>();
         statistics.put("countries", countriesStatisticResponses);
         statistics.put("monthly", monthlyStatisticResponses);
 
-//        return "admin/statistic";
         return ResponseEntity.ok(statistics);
     }
 
-    @ResponseBody
     @GetMapping("/valid-email")
     public ResponseEntity<Map<String, Boolean>> validateEmail(@RequestParam("email") String email) {
         boolean isDuplicatedEmail = adminService.isDuplicatedEmail(email);
-//        return Collections.singletonMap("email", isDuplicatedEmail);
         return ResponseEntity.ok(isDuplicatedEmail ? Collections.singletonMap("duplicated", true) : Collections.emptyMap());
     }
 
-    @ResponseBody
     @GetMapping("/valid-name")
     public ResponseEntity<Map<String, Boolean>> validateName(@RequestParam("name") String name) {
         boolean isDuplicatedName = adminService.isDuplicatedUsername(name);
-//        return Collections.singletonMap("name", isDuplicatedName);
         return ResponseEntity.ok(isDuplicatedName ? Collections.singletonMap("duplicated", true) : Collections.emptyMap());
     }
 

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -51,38 +51,18 @@ public class AdminController {
         @PathVariable("id") Long id,
         @RequestBody UserInfoUpdateRequest request
     ) {
-
         String message = null;
 
-        try {
-            adminService.updateUserInfo(id, request);
-            message =  "유저 정보가 성공적으로 수정되었습니다.";
-            return ResponseEntity.ok(getMessage(message));
-        } catch (NotFoundException e) {
-            message =  e.getMessage();
-            return ResponseEntity.status(403).body(getMessage(message));
-        } catch (Exception e) {
-            message = "알 수 없는 이유로 취소되었습니다.";
-        }
-        return ResponseEntity.status(500).body(getMessage(message));
+        adminService.updateUserInfo(id, request);
+        return ResponseEntity.ok(createSuccessMessage("유저 정보가 성공적으로 수정되었습니다."));
     }
 
     @DeleteMapping("/user-info/{id}/delete")
     public ResponseEntity<Map<String, String>> deleteUserInfo(
         @PathVariable("id") Long id
     ) {
-        String message = null;
-        try {
-            adminService.deleteById(id);
-            message =  "유저를 탈퇴처리 하였습니다.";
-            return ResponseEntity.ok(getMessage(message));
-        } catch ( NotFoundException e ) {
-            message =  e.getMessage();
-            return ResponseEntity.status(403).body(getMessage(message));
-        } catch (Exception e) {
-            message = "알 수 없는 이유로 취소되었습니다.";
-        }
-        return ResponseEntity.status(500).body(getMessage(message));
+        adminService.deleteById(id);
+        return ResponseEntity.ok(createSuccessMessage("유저를 탈퇴처리 하였습니다."));
     }
 
     private static Map<String, String> getMessage(String message) {
@@ -118,6 +98,13 @@ public class AdminController {
     public ResponseEntity<Map<String, Boolean>> validateName(@RequestParam("name") String name) {
         boolean isDuplicatedName = adminService.isDuplicatedUsername(name);
         return ResponseEntity.ok(isDuplicatedName ? Collections.singletonMap("duplicated", true) : Collections.emptyMap());
+    }
+
+    private Map<String, String> createSuccessMessage(String message) {
+        return Map.of(
+            "message", message,
+            "redirect", "/admin/user-info"
+        );
     }
 
 }

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -7,25 +7,27 @@ import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserInfoUpdateRequest
 import grepp.NBE5_6_2_Team03.domain.admin.AdminService;
 import grepp.NBE5_6_2_Team03.global.exception.NotFoundException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Controller;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin")
 public class AdminController {
@@ -38,67 +40,88 @@ public class AdminController {
     }
 
     @GetMapping("/user-info")
-    public String userInfos(
+    public ResponseEntity<Page<UserInfoResponse>> userInfos(
         @RequestParam(name = "page", defaultValue = "0") int page,
-        @RequestParam(name = "size", defaultValue = "15") int size,
-        Model model) {
+        @RequestParam(name = "size", defaultValue = "15") int size
+    ) {
         int minPageLimit = Math.max(0, page);
         Page<UserInfoResponse> userPage = adminService.findAll(PageRequest.of(minPageLimit, size));
-        model.addAttribute("userPage", userPage);
-        return "admin/user-info";
+//        model.addAttribute("userPage", userPage);
+//        return "admin/user-info";
+        return ResponseEntity.ok(userPage);
     }
 
     @PatchMapping("/user-info/{id}/edit")
-    public String editUserInfo(
+    public ResponseEntity<String> editUserInfo(
         @PathVariable("id") Long id,
-        UserInfoUpdateRequest request,
+        @RequestBody UserInfoUpdateRequest request,
         RedirectAttributes redirectAttributes) {
+
+        String message = null;
 
         try {
             adminService.updateUserInfo(id, request);
-            redirectAttributes.addFlashAttribute("message", "유저 정보가 성공적으로 수정되었습니다.");
+            message =  "유저 정보가 성공적으로 수정되었습니다.";
+            return ResponseEntity.ok(message);
         } catch (NotFoundException e) {
-            redirectAttributes.addFlashAttribute("message", e.getMessage());
+            message =  e.getMessage();
+            return ResponseEntity.status(403).body(message);
+        } catch (Exception e) {
+            message = "알 수 없는 이유로 취소되었습니다.";
         }
 
-        return "redirect:/admin/user-info";
+//        return "redirect:/admin/user-info";
+        return ResponseEntity.status(500).body(message);
     }
 
     @DeleteMapping("/user-info/{id}/delete")
-    public String deleteUserInfo(
+    public ResponseEntity<String> deleteUserInfo(
         @PathVariable("id") Long id,
         RedirectAttributes redirectAttributes
     ) {
+        String message = null;
         try {
             adminService.deleteById(id);
-            redirectAttributes.addFlashAttribute("message", "유저를 탈퇴처리 하였습니다.");
+            message =  "유저를 탈퇴처리 하였습니다.";
+            return ResponseEntity.ok(message);
         } catch ( NotFoundException e ) {
-            redirectAttributes.addFlashAttribute("message", e.getMessage());
+            message =  e.getMessage();
+            return ResponseEntity.status(403).body(message);
+        } catch (Exception e) {
+            message = "알 수 없는 이유로 취소되었습니다.";
         }
-        return "redirect:/admin/user-info";
+//        return "redirect:/admin/user-info";
+        return ResponseEntity.status(500).body(message);
     }
 
     @GetMapping("/statistic")
-    public String statistic(Model model) {
+    public ResponseEntity<Map<String, List<?>>> statistic() {
         List<CountriesStatisticResponse> countriesStatisticResponses = adminService.getCountriesStatistics();
         List<MonthlyStatisticResponse> monthlyStatisticResponses = adminService.getMonthStatistics();
-        model.addAttribute("countriesStatisticResponses", countriesStatisticResponses);
-        model.addAttribute("monthlyStatisticResponses", monthlyStatisticResponses);
-        return "admin/statistic";
+//        model.addAttribute("countriesStatisticResponses", countriesStatisticResponses);
+//        model.addAttribute("monthlyStatisticResponses", monthlyStatisticResponses);
+        Map<String, List<?>> statistics = new HashMap<>();
+        statistics.put("countries", countriesStatisticResponses);
+        statistics.put("monthly", monthlyStatisticResponses);
+
+//        return "admin/statistic";
+        return ResponseEntity.ok(statistics);
     }
 
     @ResponseBody
     @GetMapping("/valid-email")
-    public Map<String, Boolean> validateEmail(@RequestParam("email") String email) {
+    public ResponseEntity<Map<String, Boolean>> validateEmail(@RequestParam("email") String email) {
         boolean isDuplicatedEmail = adminService.isDuplicatedEmail(email);
-        return Collections.singletonMap("email", isDuplicatedEmail);
+//        return Collections.singletonMap("email", isDuplicatedEmail);
+        return ResponseEntity.ok(isDuplicatedEmail ? Collections.singletonMap("duplicated", true) : Collections.emptyMap());
     }
 
     @ResponseBody
     @GetMapping("/valid-name")
-    public Map<String, Boolean> validateName(@RequestParam("name") String name) {
+    public ResponseEntity<Map<String, Boolean>> validateName(@RequestParam("name") String name) {
         boolean isDuplicatedName = adminService.isDuplicatedUsername(name);
-        return Collections.singletonMap("name", isDuplicatedName);
+//        return Collections.singletonMap("name", isDuplicatedName);
+        return ResponseEntity.ok(isDuplicatedName ? Collections.singletonMap("duplicated", true) : Collections.emptyMap());
     }
 
 }

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -38,6 +38,7 @@ public class AdminController {
         return "admin/dashboard";
     }
 
+    // FIXME QueryDSL 페이지네이션 적용
     @GetMapping("/user-info")
     public ApiResponse<Page<UserInfoResponse>> userInfos(
         @RequestParam(name = "page", defaultValue = "0") int page,

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminControllerExceptionHandler.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminControllerExceptionHandler.java
@@ -1,0 +1,35 @@
+package grepp.NBE5_6_2_Team03.api.controller.admin;
+
+import grepp.NBE5_6_2_Team03.global.exception.NotFoundException;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackageClasses = AdminController.class)
+public class AdminControllerExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNotFoundException(NotFoundException e) {
+        log.warn("NotFoundException occurred: {}", e.getMessage());
+        return ResponseEntity.status(403)
+            .body(createErrorMessage(e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGeneralException(Exception e) {
+        log.error("Unexpected exception occurred", e);
+        return ResponseEntity.status(400)
+            .body(createErrorMessage("알 수 없는 이유로 취소되었습니다."));
+    }
+
+    private Map<String, String> createErrorMessage(String message) {
+        return Map.of(
+            "message", message,
+            "redirect", "/admin/user-info"
+        );
+    }
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,9 +25,9 @@ public class PlacesController {
     private final PlaceService placeService;
 
     @GetMapping("/info")
-    public ApiResponse<Map<String, Object>> getPlaces(PlaceSearchRequest searchRequest ) {
+    public ApiResponse<Map<String, Object>> getPlaces(@ModelAttribute PlaceSearchRequest searchRequest ) {
 //        List<PlaceResponse> places = placeService.findAll();
-        Page<PlaceResponse> result = placeService.searchPlaces(request);
+        Page<PlaceResponse> places = placeService.findPlacesPageable(searchRequest);
 
         return ApiResponse.success(createPlaceInfoResponse(places));
     }

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
@@ -39,19 +39,23 @@ public class PlacesController {
     }
 
     @PostMapping("/{id}/edit")
-    public String editPlace(@PathVariable("id") String id, PlaceRequest place,
+    public ApiResponse<Map<String, String>> editPlace(@PathVariable("id") String id, PlaceRequest place,
         RedirectAttributes redirectAttributes) {
         placeService.updatePlace(id, place);
-
-        redirectAttributes.addFlashAttribute("message", "Place updated successfully.");
-        return "redirect:/place/info";
+        return ApiResponse.success(createSuccessMessage("성공적으로 변경되었습니다."));
     }
 
     @PostMapping("/{id}/delete")
-    public String deletePlace(@PathVariable("id") String id, RedirectAttributes redirectAttributes) {
+    public ApiResponse<Map<String, String>>  deletePlace(@PathVariable("id") String id, RedirectAttributes redirectAttributes) {
         placeService.deleteById(id);
-        redirectAttributes.addFlashAttribute("message", "Place deleted successfully.");
-        return "redirect:/place/info";
+        return ApiResponse.success(createSuccessMessage("성공적으로 삭제되었습니다."));
+    }
+
+    private Map<String, String> createSuccessMessage(String message) {
+        return Map.of(
+            "message", message,
+            "redirect", "/place/info"
+        );
     }
 
     private Map<String, Object> createPlaceInfoResponse(Object obj) {

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
@@ -26,7 +26,6 @@ public class PlacesController {
 
     @GetMapping("/info")
     public ApiResponse<Map<String, Object>> getPlaces(@ModelAttribute PlaceSearchRequest searchRequest ) {
-//        List<PlaceResponse> places = placeService.findAll();
         Page<PlaceResponse> places = placeService.findPlacesPageable(searchRequest);
 
         return ApiResponse.success(createPlaceInfoResponse(places));

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
@@ -2,11 +2,13 @@ package grepp.NBE5_6_2_Team03.api.controller.admin;
 
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceRequest;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceResponse;
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceSearchRequest;
 import grepp.NBE5_6_2_Team03.domain.place.PlaceService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,8 +24,10 @@ public class PlacesController {
     private final PlaceService placeService;
 
     @GetMapping("/info")
-    public ResponseEntity<Map<String, Object>> getPlaces() {
-        List<PlaceResponse> places = placeService.findAll();
+    public ResponseEntity<Map<String, Object>> getPlaces(PlaceSearchRequest searchRequest ) {
+//        List<PlaceResponse> places = placeService.findAll();
+        Page<PlaceResponse> result = placeService.searchPlaces(request);
+
         return ResponseEntity.ok(createPlaceInfoResponse(places));
     }
 

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
@@ -24,6 +24,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 public class PlacesController {
     private final PlaceService placeService;
 
+    // STUDY ModelAttribute 어노테이션 공부
     @GetMapping("/info")
     public ApiResponse<Map<String, Object>> getPlaces(@ModelAttribute PlaceSearchRequest searchRequest ) {
         Page<PlaceResponse> places = placeService.findPlacesPageable(searchRequest);

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
@@ -4,6 +4,7 @@ import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceRequest;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceSearchRequest;
 import grepp.NBE5_6_2_Team03.domain.place.PlaceService;
+import grepp.NBE5_6_2_Team03.global.response.ApiResponse;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,17 +25,17 @@ public class PlacesController {
     private final PlaceService placeService;
 
     @GetMapping("/info")
-    public ResponseEntity<Map<String, Object>> getPlaces(PlaceSearchRequest searchRequest ) {
+    public ApiResponse<Map<String, Object>> getPlaces(PlaceSearchRequest searchRequest ) {
 //        List<PlaceResponse> places = placeService.findAll();
         Page<PlaceResponse> result = placeService.searchPlaces(request);
 
-        return ResponseEntity.ok(createPlaceInfoResponse(places));
+        return ApiResponse.success(createPlaceInfoResponse(places));
     }
 
     @GetMapping("/{id}/edit")
-    public ResponseEntity<Map<String, Object>> editPlace(@PathVariable("id") String id) {
+    public ApiResponse<Map<String, Object>> editPlace(@PathVariable("id") String id) {
         PlaceResponse place = placeService.findById(id);
-        return ResponseEntity.ok(createPlaceInfoResponse(place));
+        return ApiResponse.success(createPlaceInfoResponse(place));
     }
 
     @PostMapping("/{id}/edit")

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
@@ -3,9 +3,11 @@ package grepp.NBE5_6_2_Team03.api.controller.admin;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceRequest;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceResponse;
 import grepp.NBE5_6_2_Team03.domain.place.PlaceService;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.ui.Model;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,29 +22,19 @@ public class PlacesController {
     private final PlaceService placeService;
 
     @GetMapping("/info")
-    public String getPlaces(Model model) {
+    public ResponseEntity<Map<String, Object>> getPlaces() {
         List<PlaceResponse> places = placeService.findAll();
-        List<String> countries = placeService.getCountries();
-        List<String> cities = placeService.getCities();
-        model.addAttribute("places", places);
-        model.addAttribute("countries", countries);
-        model.addAttribute("cities", cities);
-        return "admin/place-info";
+        return ResponseEntity.ok(createPlaceInfoResponse(places));
     }
 
     @GetMapping("/{id}/edit")
-    public String editPlace(Model model, @PathVariable("id") String id) {
+    public ResponseEntity<Map<String, Object>> editPlace(@PathVariable("id") String id) {
         PlaceResponse place = placeService.findById(id);
-        List<String> countries = placeService.getCountries();
-        List<String> cities = placeService.getCities();
-        model.addAttribute("place", place);
-        model.addAttribute("countries", countries);
-        model.addAttribute("cities", cities);
-        return "place-edit";
+        return ResponseEntity.ok(createPlaceInfoResponse(place));
     }
 
     @PostMapping("/{id}/edit")
-    public String editPlace(Model model, @PathVariable("id") String id, PlaceRequest place,
+    public String editPlace(@PathVariable("id") String id, PlaceRequest place,
         RedirectAttributes redirectAttributes) {
         placeService.updatePlace(id, place);
 
@@ -55,6 +47,24 @@ public class PlacesController {
         placeService.deleteById(id);
         redirectAttributes.addFlashAttribute("message", "Place deleted successfully.");
         return "redirect:/place/info";
+    }
+
+    private Map<String, Object> createPlaceInfoResponse(Object obj) {
+        List<String> countries = placeService.getCountries();
+        List<String> cities = placeService.getCities();
+
+        Map<String, Object> body = new HashMap<>();
+
+        if (obj instanceof List<?>) {
+            body.put("places", obj);
+        } else {
+            body.put("place", obj);
+        }
+
+        body.put("countries", countries);
+        body.put("cities", cities);
+
+        return body;
     }
 
 }

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesController.java
@@ -1,19 +1,19 @@
 package grepp.NBE5_6_2_Team03.api.controller.admin;
 
-import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceRequest;
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceResponse;
 import grepp.NBE5_6_2_Team03.domain.place.PlaceService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/place")
 public class PlacesController {

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/place/PlaceResponse.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/place/PlaceResponse.java
@@ -1,11 +1,13 @@
 package grepp.NBE5_6_2_Team03.api.controller.admin.dto.place;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
 @AllArgsConstructor
+@Builder
 public class PlaceResponse {
     private String placeId;
     private String country;
@@ -13,5 +15,16 @@ public class PlaceResponse {
     private String placeName;
     private Double latitude;
     private Double longitude;
+
+    public static PlaceResponse fromEntity(String placeId, String country, String city, String placeName, double latitude, double longitude) {
+        return PlaceResponse.builder()
+            .placeId(placeId)
+            .country(country)
+            .city(city)
+            .placeName(placeName)
+            .latitude(latitude)
+            .longitude(longitude)
+            .build();
+    }
 
 }

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/place/PlaceSearchRequest.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/place/PlaceSearchRequest.java
@@ -1,0 +1,12 @@
+package grepp.NBE5_6_2_Team03.api.controller.admin.dto.place;
+
+import lombok.Getter;
+
+@Getter
+public class PlaceSearchRequest {
+    private String country;
+    private String city;
+    private String nameKeyword;
+    private int page = 0;
+    private int size = 10;
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/place/PlaceSearchRequest.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/place/PlaceSearchRequest.java
@@ -1,12 +1,47 @@
 package grepp.NBE5_6_2_Team03.api.controller.admin.dto.place;
 
-import lombok.Getter;
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
-@Getter
+@Data
+@Builder
 public class PlaceSearchRequest {
-    private String country;
-    private String city;
-    private String nameKeyword;
-    private int page = 0;
-    private int size = 10;
+    private final String country;
+    private final String city;
+
+    @Min(value = 0, message = "페이지는 0 이상이어야 합니다")
+    private final int page;
+
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다")
+    private final int size;
+
+    public PlaceSearchRequest(String country, String city, Integer page, Integer size) {
+        this.country = country;
+        this.city = city;
+        this.page = page != null ? Math.max(0, page) : 0;
+        this.size = size != null ? Math.min(Math.max(1, size), 15) : 15;
+    }
+
+    public Pageable getPageable() {
+        return PageRequest.of(this.page, this.size);
+    }
+
+    public boolean hasCountryOnly() {
+        return hasValidString(country) && !hasValidString(city);
+    }
+
+    public boolean hasCityOnly() {
+        return hasValidString(city) && !hasValidString(country);
+    }
+
+    public boolean hasNoFilter() {
+        return !hasValidString(country) && !hasValidString(city);
+    }
+
+    private boolean hasValidString(String str) {
+        return str != null && !str.trim().isEmpty();
+    }
 }

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/user/UserSearchRequest.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/user/UserSearchRequest.java
@@ -7,12 +7,13 @@ import org.springframework.data.domain.Pageable;
 
 @Getter
 @Builder
-public class UserSearchResponse {
+public class UserSearchRequest {
     private boolean locked;
     private int page;
     private int size;
 
-    public UserSearchResponse(boolean locked, int page, int size) {
+    public UserSearchRequest(boolean locked, int page, int size) {
+        this.locked = locked;
         this.page = page;
         this.size = size;
     }

--- a/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/user/UserSearchResponse.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/user/UserSearchResponse.java
@@ -1,0 +1,24 @@
+package grepp.NBE5_6_2_Team03.api.controller.admin.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+@Builder
+public class UserSearchResponse {
+    private boolean locked;
+    private int page;
+    private int size;
+
+    public UserSearchResponse(boolean locked, int page, int size) {
+        this.page = page;
+        this.size = size;
+    }
+
+    public Pageable getPageable() {
+        return PageRequest.of(this.page, this.size);
+    }
+
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
@@ -4,7 +4,7 @@ import grepp.NBE5_6_2_Team03.api.controller.admin.dto.statistic.CountriesStatist
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.statistic.MonthlyStatisticResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserInfoResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserInfoUpdateRequest;
-import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserSearchResponse;
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserSearchRequest;
 import grepp.NBE5_6_2_Team03.domain.travelplan.repository.TravelPlanRepository;
 import grepp.NBE5_6_2_Team03.domain.user.User;
 import grepp.NBE5_6_2_Team03.domain.user.repository.UserRepository;
@@ -65,9 +65,9 @@ public class AdminService {
         return userRepository.findByName(username).isPresent();
     }
 
-    public Page<UserInfoResponse> findLockedUsers(UserSearchResponse userSearchResponse) {
-        boolean isLocked = userSearchResponse.isLocked();
-        Pageable pageable = userSearchResponse.getPageable();
+    public Page<UserInfoResponse> findUsersPage(UserSearchRequest userSearchRequest) {
+        boolean isLocked = userSearchRequest.isLocked();
+        Pageable pageable = userSearchRequest.getPageable();
 
         Page<User> lockedUserInfos = userRepository.findByIsLocked(isLocked, pageable);
         return lockedUserInfos.map(this::convertToResponse);

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
@@ -4,6 +4,7 @@ import grepp.NBE5_6_2_Team03.api.controller.admin.dto.statistic.CountriesStatist
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.statistic.MonthlyStatisticResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserInfoResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserInfoUpdateRequest;
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserSearchResponse;
 import grepp.NBE5_6_2_Team03.domain.travelplan.repository.TravelPlanRepository;
 import grepp.NBE5_6_2_Team03.domain.user.User;
 import grepp.NBE5_6_2_Team03.domain.user.repository.UserRepository;
@@ -62,6 +63,28 @@ public class AdminService {
 
     public boolean isDuplicatedUsername(String username) {
         return userRepository.findByName(username).isPresent();
+    }
+
+    public Page<UserInfoResponse> findLockedUsers(UserSearchResponse userSearchResponse) {
+        boolean isLocked = userSearchResponse.isLocked();
+        Pageable pageable = userSearchResponse.getPageable();
+
+        Page<User> lockedUserInfos = userRepository.findByIsLocked(isLocked, pageable);
+        return lockedUserInfos.map(this::convertToResponse);
+    }
+
+    @Transactional
+    public void lockUser(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundException(Message.USER_NOT_FOUND));
+        user.updateIsLocked(true);
+    }
+
+    @Transactional
+    public void unLockUser(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundException(Message.USER_NOT_FOUND));
+        user.updateIsLocked(false);
     }
 
     @Transactional

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/map/MapService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/map/MapService.java
@@ -4,6 +4,8 @@ import grepp.NBE5_6_2_Team03.api.controller.map.dto.MapResponse;
 import grepp.NBE5_6_2_Team03.domain.place.entity.Place;
 import grepp.NBE5_6_2_Team03.domain.place.repository.CountryRepository;
 import grepp.NBE5_6_2_Team03.domain.place.repository.PlaceRepository;
+import grepp.NBE5_6_2_Team03.global.exception.Message;
+import grepp.NBE5_6_2_Team03.global.exception.NotFoundException;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +35,8 @@ public class MapService {
     }
 
     public MapResponse getPlace(String placeId) {
-        Place place = placeRepository.findByPlaceId(placeId);
+        Place place = placeRepository.findByPlaceId(placeId)
+            .orElseThrow(() -> new NotFoundException(Message.PLACE_NOT_FOUND));
         return convertToResponse(place);
     }
 

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/place/PlaceService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/place/PlaceService.java
@@ -5,7 +5,10 @@ import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceSearchRequest;
 import grepp.NBE5_6_2_Team03.domain.place.entity.Place;
 import grepp.NBE5_6_2_Team03.domain.place.repository.PlaceRepository;
+import grepp.NBE5_6_2_Team03.global.exception.Message;
+import grepp.NBE5_6_2_Team03.global.exception.NotFoundException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +37,7 @@ public class PlaceService {
 
     public PlaceResponse findById(String id) {
         Place place = placeRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("해당 ID의 장소를 찾을 수 없습니다: " + id));
+            .orElseThrow(() -> new NotFoundException(Message.PLACE_NOT_FOUND));
         return convertToDto(place);
     }
 
@@ -48,12 +51,9 @@ public class PlaceService {
 
     @Transactional
     public void updatePlace(String id, PlaceRequest formPlace) {
-        Place place = placeRepository.findByPlaceId(id);
-        if (place == null) {
-            throw new IllegalArgumentException("해당 ID의 장소를 찾을 수 없습니다: " + id);
-        }
+        Place place = placeRepository.findByPlaceId(id)
+            .orElseThrow(() -> new NotFoundException(Message.PLACE_NOT_FOUND));
 
-        // TODO 방어적 복사 개념 공부하기
         place.update(
             formPlace.getCity(),
             formPlace.getCountry(),
@@ -61,16 +61,12 @@ public class PlaceService {
             formPlace.getLatitude(),
             formPlace.getLongitude()
         );
-
-        //STUDY Transactional 어노테이션을 사용하면 종료시점에 자동으로 커밋을 update 쿼리로 날려준다.
     }
 
     @Transactional
     public void deleteById(String id) {
-        Place place = placeRepository.findByPlaceId(id);
-        if (place == null) {
-            throw new IllegalArgumentException("해당 장소를 찾을 수 없습니다: " + id);
-        }
+        Place place = placeRepository.findByPlaceId(id)
+            .orElseThrow(() -> new NotFoundException(Message.PLACE_NOT_FOUND));
         placeRepository.delete(place);
     }
 

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/place/PlaceService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/place/PlaceService.java
@@ -65,14 +65,13 @@ public class PlaceService {
     }
 
     private PlaceResponse convertToDto(Place place) {
-        return new PlaceResponse(
+        return PlaceResponse.fromEntity(
             place.getPlaceId(),
             place.getCountry(),
             place.getCity(),
             place.getPlaceName(),
             place.getLatitude(),
-            place.getLongitude()
-        );
+            place.getLongitude());
     }
 
 }

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/place/PlaceService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/place/PlaceService.java
@@ -1,21 +1,20 @@
 package grepp.NBE5_6_2_Team03.domain.place;
 
-import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceResponse;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceRequest;
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceResponse;
 import grepp.NBE5_6_2_Team03.domain.place.entity.Place;
 import grepp.NBE5_6_2_Team03.domain.place.repository.PlaceRepository;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class PlaceService {
-    private final PlaceRepository placeRepository;
 
-    public PlaceService(PlaceRepository placeRepository) {
-        this.placeRepository = placeRepository;
-    }
+    private final PlaceRepository placeRepository;
 
     public List<PlaceResponse> findAll() {
         List<Place> places =  placeRepository.findAll();

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/place/PlaceService.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/place/PlaceService.java
@@ -2,16 +2,21 @@ package grepp.NBE5_6_2_Team03.domain.place;
 
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceRequest;
 import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceResponse;
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceSearchRequest;
 import grepp.NBE5_6_2_Team03.domain.place.entity.Place;
 import grepp.NBE5_6_2_Team03.domain.place.repository.PlaceRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PlaceService {
 
     private final PlaceRepository placeRepository;
@@ -19,6 +24,12 @@ public class PlaceService {
     public List<PlaceResponse> findAll() {
         List<Place> places =  placeRepository.findAll();
         return places.stream().map(this::convertToDto).collect(Collectors.toList());
+    }
+
+    public Page<PlaceResponse> findPlacesPageable(PlaceSearchRequest req) {
+        Page<Place> places = placeRepository.findPaged(req.getCountry(), req.getCity(), req.getPageable());
+        log.debug("Found {} places", places.getTotalElements());
+        return places.map(this::convertToDto);
     }
 
     public PlaceResponse findById(String id) {

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/place/repository/PlaceRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PlaceRepository extends JpaRepository<Place, String> {
+public interface PlaceRepository extends JpaRepository<Place, String>, PlaceRepositoryCustom {
 
     Place findByPlaceId(String placeId);
 

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/place/repository/PlaceRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface PlaceRepository extends JpaRepository<Place, String>, PlaceRepositoryCustom {
 
-    Place findByPlaceId(String placeId);
+    Optional<Place> findByPlaceId(String placeId);
 
     @Query("select distinct p.country from Place p order by p.country")
     List<String> findDistinctCountries();

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/place/repository/PlaceRepositoryCustom.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/place/repository/PlaceRepositoryCustom.java
@@ -1,0 +1,9 @@
+package grepp.NBE5_6_2_Team03.domain.place.repository;
+
+import grepp.NBE5_6_2_Team03.domain.place.entity.Place;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PlaceRepositoryCustom {
+    Page<Place> findPaged(String country, String city, Pageable pageable);
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/place/repository/PlaceRepositoryCustomImpl.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/place/repository/PlaceRepositoryCustomImpl.java
@@ -1,0 +1,44 @@
+package grepp.NBE5_6_2_Team03.domain.place.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import grepp.NBE5_6_2_Team03.domain.place.entity.Place;
+import grepp.NBE5_6_2_Team03.domain.place.entity.QPlace;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class PlaceRepositoryCustomImpl implements PlaceRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QPlace place = QPlace.place;
+
+    @Override
+    public Page<Place> findPaged(String country, String city, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (country != null && !country.isBlank()) {
+            builder.and(place.country.eq(country));
+        }
+        if (city != null && !city.isBlank()) {
+            builder.and(place.city.eq(city));
+        }
+
+        List<Place> content = jpaQueryFactory
+            .selectFrom(place)
+            .where(builder)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long total = jpaQueryFactory
+            .selectFrom(place)
+            .where(builder)
+            .fetchCount();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserCustomRepository.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserCustomRepository.java
@@ -1,0 +1,9 @@
+package grepp.NBE5_6_2_Team03.domain.user.repository;
+
+import grepp.NBE5_6_2_Team03.domain.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserCustomRepository {
+    Page<User> findByIsLocked(boolean isLocked, Pageable pageable);
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserCustomRepositoryImpl.java
@@ -1,0 +1,45 @@
+package grepp.NBE5_6_2_Team03.domain.user.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import grepp.NBE5_6_2_Team03.domain.user.QUser;
+import grepp.NBE5_6_2_Team03.domain.user.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QUser user = QUser.user;
+
+    @Override
+    public Page<User> findByIsLocked(boolean isLocked, Pageable pageable) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(isLocked) {
+            builder.and(user.isLocked.eq(true));
+        }
+        else{
+            builder.and(user.isLocked.eq(false));
+        }
+
+        List<User> users = jpaQueryFactory
+            .selectFrom(user)
+            .where(builder)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        long total = jpaQueryFactory
+            .selectFrom(user)
+            .where(builder)
+            .fetchCount();
+
+        return new PageImpl<>(users, pageable, total);
+    }
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserRepository.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
     Optional<User> findByEmail(String email);
     Optional<User> findByName(String name);
 

--- a/src/main/java/grepp/NBE5_6_2_Team03/global/config/querydsl/QuerydslConfig.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/global/config/querydsl/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package grepp.NBE5_6_2_Team03.global.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/grepp/NBE5_6_2_Team03/global/exception/Message.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/global/exception/Message.java
@@ -6,6 +6,7 @@ public enum Message {
     USER_NOT_MATCH_PASSWORD("회원의 비밀번호가 일치하지 않습니다."),
     ADMIN_NOT_DELETE("관리자 계정은 삭제할 수 없습니다"),
     PLANNED_NOT_FOUND("해당 여행 계획이 존재하지 않습니다."),
+    PLACE_NOT_FOUND("해당 장소가 존재하지 않습니다."),
     SCHEDULE_NOT_FOUND("해당 일정이 존재하지 않습니다."),
     EXPENSE_NOT_FOUND("해당 지출이 존재하지 않습니다.");
 

--- a/src/main/java/grepp/NBE5_6_2_Team03/global/exception/handler/AdminControllerExceptionHandler.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/global/exception/handler/AdminControllerExceptionHandler.java
@@ -1,9 +1,9 @@
-package grepp.NBE5_6_2_Team03.api.controller.admin;
+package grepp.NBE5_6_2_Team03.global.exception.handler;
 
+import grepp.NBE5_6_2_Team03.api.controller.admin.AdminController;
 import grepp.NBE5_6_2_Team03.global.exception.NotFoundException;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/src/main/java/grepp/NBE5_6_2_Team03/global/exception/handler/AdminControllerExceptionHandler.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/global/exception/handler/AdminControllerExceptionHandler.java
@@ -2,6 +2,8 @@ package grepp.NBE5_6_2_Team03.global.exception.handler;
 
 import grepp.NBE5_6_2_Team03.api.controller.admin.AdminController;
 import grepp.NBE5_6_2_Team03.global.exception.NotFoundException;
+import grepp.NBE5_6_2_Team03.global.response.ApiResponse;
+import grepp.NBE5_6_2_Team03.global.response.ResponseCode;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -13,17 +15,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class AdminControllerExceptionHandler {
 
     @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleNotFoundException(NotFoundException e) {
+    public ApiResponse<Map<String, String>> handleNotFoundException(NotFoundException e) {
         log.warn("NotFoundException occurred: {}", e.getMessage());
-        return ResponseEntity.status(403)
-            .body(createErrorMessage(e.getMessage()));
+        return ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR, createErrorMessage(e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, String>> handleGeneralException(Exception e) {
+    public ApiResponse<Map<String, String>> handleGeneralException(Exception e) {
         log.error("Unexpected exception occurred", e);
-        return ResponseEntity.status(400)
-            .body(createErrorMessage("알 수 없는 이유로 취소되었습니다."));
+        return ApiResponse.error(ResponseCode.BAD_REQUEST, createErrorMessage("알 수 없는 이유로 취소되었습니다."));
     }
 
     private Map<String, String> createErrorMessage(String message) {

--- a/src/main/java/grepp/NBE5_6_2_Team03/global/exception/handler/AdminControllerExceptionHandler.java
+++ b/src/main/java/grepp/NBE5_6_2_Team03/global/exception/handler/AdminControllerExceptionHandler.java
@@ -6,7 +6,6 @@ import grepp.NBE5_6_2_Team03.global.response.ApiResponse;
 import grepp.NBE5_6_2_Team03.global.response.ResponseCode;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 

--- a/src/main/resources/templates/admin/user-info.html
+++ b/src/main/resources/templates/admin/user-info.html
@@ -113,7 +113,7 @@
 </head>
 <body class="bg-light">
 <header>
-  <div class="site-title">여행 통계</div>
+  <div class="site-title">유저 목록</div>
   <div class="nav-links">
     <a href="/admin/dashboard">대시보드</a>
     <form id="logoutForm" action="/users/logout" method="post" style="display: inline;">

--- a/src/test/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminControllerTest.java
+++ b/src/test/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminControllerTest.java
@@ -1,0 +1,49 @@
+package grepp.NBE5_6_2_Team03.api.controller.admin;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserInfoResponse;
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserSearchRequest;
+import grepp.NBE5_6_2_Team03.global.response.ApiResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class AdminControllerTest {
+
+    @Autowired
+    private AdminController adminController;
+
+    @Test
+    void findUsersPage() {
+        // given
+        UserSearchRequest request = UserSearchRequest
+            .builder()
+            .locked(true)
+            .page(0)
+            .size(10)
+            .build();
+
+        // when
+        ApiResponse<Page<UserInfoResponse>> result = adminController.userInfos(request);
+
+        // then
+        List<UserInfoResponse> content = result.data().getContent();
+
+        assertThat(content)
+            .hasSize(2)
+            .extracting("email", "name", "locked")
+            .containsExactlyInAnyOrder(
+                tuple("user16@example.com", "회원16", true),
+                tuple("user17@example.com", "회원17", true)
+            );
+    }
+
+}

--- a/src/test/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesControllerTest.java
+++ b/src/test/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesControllerTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+// FIXME : @WebMvcTest(PlaceController.class) 사용한 테스트로 변경
 @SpringBootTest
 @AutoConfigureMockMvc
 class PlacesControllerTest {
@@ -26,6 +27,7 @@ class PlacesControllerTest {
     @Autowired
     private PlacesController placesController; // You might not even need this if you're only testing via mockMvc
 
+    // FIXME : AssertJ 로 변경
     @Test
     @DisplayName("여행지 페이지 페이지네이션 메서드 동작 테스트")
     void getPlaceInfoPage() throws JsonProcessingException, JsonProcessingException {
@@ -39,6 +41,7 @@ class PlacesControllerTest {
         }
     }
 
+    // FIXME : AssertJ 로 변경
     @Test
     @DisplayName("여행지 페이지 페이지네이션 WebMvc 테스트")
     void getPlaceInfoPage_webMvc() throws Exception {

--- a/src/test/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesControllerTest.java
+++ b/src/test/java/grepp/NBE5_6_2_Team03/api/controller/admin/PlacesControllerTest.java
@@ -1,0 +1,57 @@
+package grepp.NBE5_6_2_Team03.api.controller.admin;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.place.PlaceSearchRequest;
+import grepp.NBE5_6_2_Team03.global.response.ApiResponse;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PlacesControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PlacesController placesController; // You might not even need this if you're only testing via mockMvc
+
+    @Test
+    @DisplayName("여행지 페이지 페이지네이션 메서드 동작 테스트")
+    void getPlaceInfoPage() throws JsonProcessingException, JsonProcessingException {
+        for (int i = 0; i < 3; i++){
+            PlaceSearchRequest searchRequest = new PlaceSearchRequest("일본", "도쿄", i, 3);
+            ApiResponse<Map<String, Object>> result = placesController.getPlaces(searchRequest);
+            ObjectMapper objectMapper = new ObjectMapper();
+            String jsonResult = objectMapper.writerWithDefaultPrettyPrinter()
+                .writeValueAsString(result);
+            System.out.println(jsonResult);
+        }
+    }
+
+    @Test
+    @DisplayName("여행지 페이지 페이지네이션 WebMvc 테스트")
+    void getPlaceInfoPage_webMvc() throws Exception {
+        for (int i = 0; i < 3; i++) {
+            PlaceSearchRequest searchRequest = new PlaceSearchRequest("일본", "도쿄", i, 3);
+
+            mockMvc.perform(get("/place/info")
+                    .param("country", searchRequest.getCountry())
+                    .param("city", searchRequest.getCity())
+                    .param("page", String.valueOf(searchRequest.getPage()))
+                    .param("size", String.valueOf(searchRequest.getSize())))
+                .andExpect(status().isOk())
+                .andDo(print());
+        }
+    }
+}

--- a/src/test/java/grepp/NBE5_6_2_Team03/domain/admin/AdminServiceTest.java
+++ b/src/test/java/grepp/NBE5_6_2_Team03/domain/admin/AdminServiceTest.java
@@ -1,0 +1,45 @@
+package grepp.NBE5_6_2_Team03.domain.admin;
+
+import grepp.NBE5_6_2_Team03.domain.user.User;
+import grepp.NBE5_6_2_Team03.domain.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class AdminServiceTest {
+
+    @Autowired
+    private AdminService adminService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("유저 잠금 테스트")
+    @Transactional
+    void lockedUserTest() {
+        Optional<User> user = userRepository.findById(3L);
+        assertTrue(user.isPresent());
+        adminService.lockUser(user.get().getId());
+        assertTrue(user.get().isLocked());
+    }
+
+    @Test
+    @DisplayName("유저 잠금해제 테스트")
+    @Transactional
+    void unlockedUserTest() {
+        Optional<User> user = userRepository.findById(3L);
+        assertTrue(user.isPresent());
+        adminService.lockUser(user.get().getId());
+        assertTrue(user.get().isLocked());
+        adminService.unLockUser(user.get().getId());
+        assertFalse(user.get().isLocked());
+    }
+
+}

--- a/src/test/java/grepp/NBE5_6_2_Team03/domain/admin/AdminServiceTest.java
+++ b/src/test/java/grepp/NBE5_6_2_Team03/domain/admin/AdminServiceTest.java
@@ -1,5 +1,6 @@
 package grepp.NBE5_6_2_Team03.domain.admin;
 
+import grepp.NBE5_6_2_Team03.api.controller.admin.dto.user.UserSearchRequest;
 import grepp.NBE5_6_2_Team03.domain.user.User;
 import grepp.NBE5_6_2_Team03.domain.user.repository.UserRepository;
 import java.util.Optional;


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Admin관련 페이지인 admin과 place에 대해 RestController 변경 및 예외처리 로직 변경, QueryDSL을 이용한 페이지네이션 및 필터링으로 변경하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
레디스를 이용한 페이지네이션 및 필터링을 하기전에 QueryDSL로 페이지네이션을 하도록 변경하였습니다.
또한, 예외 처리방식을 기존의 IllegalArgumentException대신 NotFoundException과 Message를 추가해 이것으로 예외처리를 하도록 변경하였습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
